### PR TITLE
[2] - Type change

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,20 @@ To build the SDK and see changes, follow these steps:
    git clone <repository_url>
    cd <repository_directory>
 
-2. Install dependencies and setup modules using setup.py :
+2. Make sure you have python installed. You can download it from [here](https://www.python.org/downloads/). After that install setuptools using:
+     ```bash
+     pip install setuptools
+
+3. Install dependencies and setup modules using setup.py :
 
      ```bash
-     python setup.py
+     python setup.py install
+
+## Required Dependencies
+- substrate-interface
+- base58
+- mnemonic
+- pynacl
 
 ## Experimenting with SDK Methods
 ## Demo Methods

--- a/README.md
+++ b/README.md
@@ -20,14 +20,16 @@ Before you begin, ensure that you have the following:
      ```
 
    - If pip is not installed, you can install it by following these steps:
-     
-       ```bash
-       sudo apt install python3-pip
-       ```
-     
+     ```bash
+     sudo apt install python3-pip
+     ```
 
 3. **Setuptools**:
-   - Setuptools is required to manage the installation of Python packages. Install it using:
+   - Setuptools is required to manage the installation of Python packages. First, check if it is already installed:
+     ```bash
+     pip show setuptools
+     ```
+   - If it is not installed, you can install it using:
      ```bash
      pip3 install setuptools
      ```

--- a/README.md
+++ b/README.md
@@ -1,44 +1,76 @@
 # CORD.py
 CORD.py is a Python library that provides a collection of classes and methods to interact with the Cord blockchain network.
 
+## Prerequisites for Building the SDK
+
+Before you begin, ensure that you have the following:
+
+1. **Python 3.10 or higher**:
+   - CORD.py requires Python version 3.10 or higher. You can check your Python version by running:
+     ```bash
+     python3 --version
+     ```
+
+   - If you do not have Python installed, you can download it from the [official Python website](https://www.python.org/downloads/).
+
+2. **pip**:
+   - pip is the package installer for Python. It is usually included with Python, but you can verify its installation with:
+     ```bash
+     pip3 --version
+     ```
+
+   - If pip is not installed, you can install it by following these steps:
+     
+       ```bash
+       sudo apt install python3-pip
+       ```
+     
+
+3. **Setuptools**:
+   - Setuptools is required to manage the installation of Python packages. Install it using:
+     ```bash
+     pip3 install setuptools
+     ```
+
 ## Building the SDK
 
 To build the SDK and see changes, follow these steps:
 
-1. Clone this repository to your local machine:
-
-   ```bash
-   git clone <repository_url>
-   cd <repository_directory>
-
-2. Make sure you have python installed. You can download it from [here](https://www.python.org/downloads/). After that install setuptools using:
+1. **Clone the repository**:
+   - Clone this repository to your local machine and navigate to the directory:
      ```bash
-     pip install setuptools
+     git clone <repository_url>
+     cd <repository_directory>
+     ```
 
-3. Install dependencies and setup modules using setup.py :
-
+2. **Install dependencies and set up modules**:
+   - Use the `setup.py` script to install dependencies and set up the modules:
      ```bash
-     python setup.py install
+     python3 setup.py install
+     ```
 
 ## Required Dependencies
+
+CORD.py relies on several Python libraries. These dependencies will be installed when you run the `setup.py` script:
+
 - [substrate-interface](https://polkascan.github.io/py-substrate-interface/)
 - [base58](https://pypi.org/project/base58/)
 - [mnemonic](https://pypi.org/project/mnemonic/)
 - [pynacl](https://pypi.org/project/PyNaCl/)
 
 ## Experimenting with SDK Methods
-## Demo Methods
-Once the SDK is built, you can experiment with the provided methods.
 
-## Statement Method:
+After building the SDK, you can experiment with the provided methods.
+
+### Demo Methods
+
+The SDK includes demo methods to help you interact with the Cord blockchain network.
+
+### Statement Method:
 
 The `demo-statement` method allows you to interact with statement-related functionalities.
 
 To run the statement demo, execute the following command:
 
 ```bash
-python -u "demo/src/func_tests.py"
-```
-
-The output of each demo script will demonstrate the functionality of the corresponding method. For a detailed structure of the demo scripts, refer to the source code.
-
+python3 -u "demo/src/func_tests.py"

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ To build the SDK and see changes, follow these steps:
      python setup.py install
 
 ## Required Dependencies
-- substrate-interface
-- base58
-- mnemonic
-- pynacl
+- [substrate-interface](https://polkascan.github.io/py-substrate-interface/)
+- [base58](https://pypi.org/project/base58/)
+- [mnemonic](https://pypi.org/project/mnemonic/)
+- [pynacl](https://pypi.org/project/PyNaCl/)
 
 ## Experimenting with SDK Methods
 ## Demo Methods

--- a/custom-type.json
+++ b/custom-type.json
@@ -30,7 +30,7 @@
                         ],
                         [
                             "service_endpoints",
-                            "Vec<scale_info::219>"
+                            "Vec<pallet_did::service_endpoints::DidEndpoint<T>>"
                         ],
                         [
                             "details",

--- a/packages/did/src/Did_chain.py
+++ b/packages/did/src/Did_chain.py
@@ -174,7 +174,7 @@ async def get_store_tx(input, submitter, sign_callback):
         'new_service_details': new_service_details,
     }
     
-    encoded = api.encode_scale(type_string='scale_info::217',value=api_input)
+    encoded = api.encode_scale(type_string='pallet_did::did_details::DidCreationDetails<sp_core::crypto::AccountId32, sp_core::crypto::AccountId32, cord_loom_runtime::MaxNewKeyAgreementKeys, pallet_did::service_endpoints::DidEndpoint<T>>',value=api_input)
     
     signature = sign_callback(encoded)
     encoded_signature = {signature['key_type']: '0x' + signature['signature'].hex()}


### PR DESCRIPTION
Removed the use of scale_info::`type` as `type` number changes after every change in CORD similiar to changes in augment-api in cord.js. 
Instead used names of the types directly.

@vatsa287 @adi-a11y Please merge it before merging the other PRs so that you can test other functions on your systems and CORD version.